### PR TITLE
accept local file paths as url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Feed validator
-Simple validator for feeds like RSS or Atom. Supports opensearch.xml validation. 
+Simple validator for feeds like RSS or Atom. Supports opensearch.xml validation.
 Based on validator.w3.org/feed
 
 Supports plugins for custom checks
@@ -24,7 +24,7 @@ Simple validator for RSS, Atom or opensearch.xml that using validator.w3.
 org/feed and plugins
 
 Positional arguments:
-  url                   Feed url to validate
+  url                   Feed url or file-path to validate
 
 Optional arguments:
   -h, --help            Show this help message and exit.
@@ -40,7 +40,7 @@ Optional arguments:
 Options can be defined by command line and configuration file.
 
 ### url
-URL of the validated feed.
+URL or file-path of the validated feed.
 
 ### config
 Configuration file. Can be passed from command line. Example of config file see in `examples` folder.
@@ -52,7 +52,7 @@ Reporter type: text or JSON. Can be defined in command line: `--reporter json` o
 Don't use colors in report. Can be passed from command line: `--no-colors` and from config file: `noColors: true`.
 
 ### suppress
-You can suppress some messages by defining objects that contains fields to match in config file. 
+You can suppress some messages by defining objects that contains fields to match in config file.
 Example of suppressing:
 ```js
 suppress: [
@@ -62,9 +62,9 @@ suppress: [
 ```
 
 ### plugins
-Can be defined in config file (see `examples`). Each plugin is function that take JSON feed representation and returns errors, 
+Can be defined in config file (see `examples`). Each plugin is function that take JSON feed representation and returns errors,
 warnings and information messages list.
- 
+
 Plugin function example:
 ```js
 /**
@@ -95,4 +95,4 @@ function checkHttps(feedJson, options) {
     return errors;
 }
 ```
-You should define `level` and `text` fields. And you can define your own custom `type` field. 
+You should define `level` and `text` fields. And you can define your own custom `type` field.

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "argparse": "^1.0.2",
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",
+    "fs-readfile-promise": "^3.0.0",
     "lodash": "^3.10.1",
     "q": "^1.4.1",
     "q-io": "^1.13.1",
     "throw": "^1.0.0",
+    "valid-url": "^1.0.9",
     "xml2js": "^0.4.10"
   },
   "devDependencies": {

--- a/providers/feed.js
+++ b/providers/feed.js
@@ -6,14 +6,16 @@ var Q = require('q');
 var Http = require('q-io/http');
 var parseXml = require('xml2js').parseString;
 var thr = require('throw');
+var validUrl = require('valid-url');
+var readFile = require('fs-readfile-promise');
 
 /**
- * Get feed from URL
- * @param {String} url
+ * Get feed from URL or local file
+ * @param {String} url URI of local file path
  * @returns {Promise<Object>} Feed JSON representation
  */
 module.exports = function feedProvider(url) {
-    return Http.read(url)
+    return (validUrl.isUri(url) ? Http.read(url) : readFile(url))
         .catch(function (err) {
             thr('Transport error: %s', err);
         })


### PR DESCRIPTION
This change makes it possible to use the validator on local files (e.g. after generating them).

Example:
`feed-validator ./feeds/myNewsFeed.xml`